### PR TITLE
Fix actions registration

### DIFF
--- a/src/config/functions/bootstrap.js
+++ b/src/config/functions/bootstrap.js
@@ -28,5 +28,5 @@ module.exports = async () => {
   }
 
   const { actionProvider } = global.strapi.admin.services.permission;
-  actionProvider.register(actions);
+  actionProvider.registerMany(actions);
 };


### PR DESCRIPTION
The way you register actions through a plugin has changed in 3.6.0. See https://github.com/strapi/strapi/blob/master/packages/strapi-plugin-upload/config/functions/bootstrap.js#L142 for an example.

This is a first step towards compatibility with 3.6.0. #13 still needs to be done before it can be used.