### PR TITLE
Inject values of attributes, allow custom urls for each content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 - Add ability to define a custom preview url for each content type
-- Add ability to use an the values of an entry's attributes in the url
+- Add ability to use any of the values of an entry's attributes in the url
 - Add a base url setting to avoid duplication between default preview url and custom ones
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.1](https://github.com/danestves/strapi-plugin-preview-content/compare/v1.1.0...v1.1.1) (2021-05-05)
+
 ## [1.1.0](https://github.com/danestves/strapi-plugin-preview-content/compare/v1.1.0-alpha.0...v1.1.0) (2021-05-05)
 
 ## [1.1.0-alpha.0](https://github.com/danestves/strapi-plugin-preview-content/compare/v1.0.3-alpha.2...v1.1.0-alpha.0) (2021-05-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [Unreleased]
+
+### Features
+- Add ability to define a custom preview url for each content type
+- Add ability to use an the values of an entry's attributes in the url
+- Add a base url setting to avoid duplication between default preview url and custom ones
+
+### Enhancements
+- Use `pluginOptions` on models to configure the plugin
+
 ### [1.1.1](https://github.com/danestves/strapi-plugin-preview-content/compare/v1.1.0...v1.1.1) (2021-05-05)
 
 ## [1.1.0](https://github.com/danestves/strapi-plugin-preview-content/compare/v1.1.0-alpha.0...v1.1.0) (2021-05-05)

--- a/README.md
+++ b/README.md
@@ -87,15 +87,17 @@ Go to Settings > Preview Content
 
 #### Base url
 
-Here you can configure the base url of your frontend. This is a seperate field because it will be different depending on if your project is running locally (e.g. `http://localhost:3000`) oder in production (e.g. `https://your-site.com`)
+Here you can configure the base url of your frontend. This is a seperate field because it will be different depending on whether your project is running locally (e.g. `http://localhost:3000`) oder in production (e.g. `https://your-site.com`).
 
 #### Default preview url
 
-The default preview url for when your content type doesn't have it's own url defined. For the default preview url there are three parameters provided by the plugin:
+This is the default preview url the plugin uses for when your content type doesn't have its own url defined. For the default preview url there are three parameters provided by this plugin:
 
-`:baseUrl` 
-`:contentType` The content type to query
-`:id` The id of content to query
+| Parameter       | Description                       |
+|-----------------|-----------------------------------|
+| `:baseUrl`      | See section above for explanation |
+| `:contentType`  | The content type to query         |
+| `:id`           | The id of content to query        | 
 
 For example in NextJS you can make use of [serverless functions](https://nextjs.org/docs/api-routes/introduction) to make an URL like this:
 
@@ -107,7 +109,7 @@ And put the logic there to render content.
 
 #### Custom preview url
 
-You can also provide a custom url in a model's `*.settings.json` for more flexibility. To do that, add this line to it's options:
+You can also provide a custom url per content type in its `*.settings.json`. To do so, add this line to its options:
 
 ```diff
 {
@@ -120,11 +122,11 @@ You can also provide a custom url in a model's `*.settings.json` for more flexib
 }
 ```
 
-Here you can see how the base url comes in handy: You cannot change your model for production, but you can change the base url in the settings.
+Here you can see how the base url comes in handy: You cannot change the model in production, but you can change the base url in the settings.
 
 #### Adding data to the url
 
-To tell the plugin to allow injecting data of the entry add the following to your model's `*.settings.json`:
+To tell the plugin to allow injection of an entry's data add the following to your model's `*.settings.json`:
 
 ```diff
 {
@@ -138,7 +140,7 @@ To tell the plugin to allow injecting data of the entry add the following to you
 }
 ```
 
-The plugin will now replace `<%= slug %>` and `<%= title %>` with the correct values. Make sure that you don't use names of attributes that don't exist, else you will get an error.
+The plugin will now replace `<%= slug %>` and `<%= title %>` with the correct values. What you put in the brackets (`<%=` `%>`) has to be a name of the an attribute.
 The syntax used here is [lodash's template syntax](https://lodash.com/docs/4.17.15#template).
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ To enable content type to be previewable and see preview, or clone entry, you've
 
 ```diff
 {
-  "options": {
-+    "previewable": true
+  "pluginOptions": {
++    "preview-content": {
++      "previewable": true
++    }
   }
 }
 ```
@@ -83,16 +85,61 @@ Go to Settings > Preview Content
 
 <img src="https://github.com/danestves/strapi-plugin-preview-content/blob/main/public/assets/settings.png?raw=true" alt="Preview Content Settings" />
 
-Here you can configure how your url for frontend preview, at the moment there are only two parameters
+#### Base url
 
+Here you can configure the base url of your frontend. This is a seperate field because it will be different depending on if your project is running locally (e.g. `http://localhost:3000`) oder in production (e.g. `https://your-site.com`)
+
+#### Default preview url
+
+The default preview url for when your content type doesn't have it's own url defined. For the default preview url there are three parameters provided by the plugin:
+
+`:baseUrl` 
 `:contentType` The content type to query
 `:id` The id of content to query
 
 For example in NextJS you can make use of [serverless functions](https://nextjs.org/docs/api-routes/introduction) to make an URL like this:
 
-`http://localhost:3000/api/preview/:contentType/:id`
+`:baseUrl/api/preview/:contentType/:id`
 
-And put the logic there to render content
+With your base url being `http://localhost:3000`, for example.
+
+And put the logic there to render content.
+
+#### Custom preview url
+
+You can also provide a custom url in a model's `*.settings.json` for more flexibility. To do that, add this line to it's options:
+
+```diff
+{
+  "pluginOptions": {
+    "preview-content": {
+      "previewable": true,
++      "url": ":baseUrl/your-path/:contentType/:id?a-custom-param=true"
+    }
+  }
+}
+```
+
+Here you can see how the base url comes in handy: You cannot change your model for production, but you can change the base url in the settings.
+
+#### Adding data to the url
+
+To tell the plugin to allow injecting data of the entry add the following to your model's `*.settings.json`:
+
+```diff
+{
+  "pluginOptions": {
+    "preview-content": {
+      "previewable": true,
++      "url": ":baseUrl/your-path/:contentType/<%= slug %>?a-custom-param=<%= title %>",
++      "usesValuesInUrl": true
+    }
+  }
+}
+```
+
+The plugin will now replace `<%= slug %>` and `<%= title %>` with the correct values. Make sure that you don't use names of attributes that don't exist, else you will get an error.
+The syntax used here is [lodash's template syntax](https://lodash.com/docs/4.17.15#template).
 
 ### ✨ Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-content",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Preview your content with custom URL.",
   "main": "admin/main/index.js",
   "strapi": {

--- a/src/admin/src/containers/SettingsPage/index.js
+++ b/src/admin/src/containers/SettingsPage/index.js
@@ -2,9 +2,9 @@ import React, { useEffect, useReducer, useRef } from "react";
 import { Header, Inputs } from "@buffetjs/custom";
 import {
   LoadingIndicatorPage,
-  useGlobalContext,
   request,
 } from "strapi-helper-plugin";
+import { useIntl } from "react-intl";
 import { isEqual } from "lodash";
 
 import { getRequestUrl, getTrad } from "../../utils";
@@ -16,7 +16,7 @@ import init from "./init";
 import reducer, { initialState } from "./reducer";
 
 const SettingsPage = () => {
-  const { formatMessage } = useGlobalContext();
+  const { formatMessage } = useIntl();
   const [reducerState, dispatch] = useReducer(reducer, initialState, init);
   const { initialData, isLoading, modifiedData } = reducerState.toJS();
   const isMounted = useRef(true);
@@ -132,6 +132,20 @@ const SettingsPage = () => {
             <div className="col-12">
               <Inputs
                 label={formatMessage({
+                  id: getTrad("settings.form.baseUrl.label"),
+                })}
+                description={formatMessage({
+                  id: getTrad("settings.form.baseUrl.description"),
+                })}
+                name="baseUrl"
+                onChange={handleChange}
+                type="text"
+                value={modifiedData.baseUrl}
+              />
+            </div>
+            <div className="col-12">
+              <Inputs
+                label={formatMessage({
                   id: getTrad("settings.form.previewUrl.label"),
                 })}
                 description={formatMessage({
@@ -153,6 +167,23 @@ const SettingsPage = () => {
               <hr className="mt-0 mb-2" />
 
               <div>
+                <div className="d-flex py-2 align-items-center">
+                  <CodeBlock
+                    fontSize="md"
+                    color="#ffffff"
+                    className="p-2 rounded"
+                  >
+                    :baseUrl
+                  </CodeBlock>
+
+                  <Text fontSize="md" color="#787E8F" className="ml-2">
+                    {formatMessage({
+                      id: getTrad(
+                        "settings.form.previewUrl.available.baseUrl"
+                      ),
+                    })}
+                  </Text>
+                </div>
                 <div className="d-flex py-2 align-items-center">
                   <CodeBlock
                     fontSize="md"

--- a/src/admin/src/containers/SettingsPage/reducer.js
+++ b/src/admin/src/containers/SettingsPage/reducer.js
@@ -4,9 +4,11 @@ const initialState = fromJS({
   isLoading: true,
   initialData: {
     previewUrl: "",
+    baseUrl: "",
   },
   modifiedData: {
     previewUrl: "",
+    baseUrl: "",
   },
 });
 

--- a/src/admin/src/translations/en.json
+++ b/src/admin/src/translations/en.json
@@ -14,9 +14,12 @@
   "popUpWarning.warning.publish-question": "Are you sure you want to publish this entry?",
 
   "plugin.name": "Preview Content",
+  "settings.form.baseUrl.description": "The root url of your frontend. This can be used by custom and default preview urls.",
+  "settings.form.baseUrl.label": "Base url",
   "settings.form.previewUrl.description": "Create custom preview url to be used in your frontend",
-  "settings.form.previewUrl.label": "Preview url",
+  "settings.form.previewUrl.label": "Default Preview url",
   "settings.form.previewUrl.available": "Available parameters:",
+  "settings.form.previewUrl.available.baseUrl": "The root url as defined above",
   "settings.form.previewUrl.available.contentType": "The content type to query (required in the url)",
   "settings.form.previewUrl.available.id": "The id to query (required in the url)",
   "settings.form.previewUrl.example": "Example:",

--- a/src/config/functions/bootstrap.js
+++ b/src/config/functions/bootstrap.js
@@ -22,7 +22,8 @@ module.exports = async () => {
   if (!config) {
     await configurator.set({
       value: {
-        previewUrl: "<YOUR_URL>/api/preview?contentType=:contentType&id=:id",
+        baseUrl: "https://<YOUR_URL>.com",
+        previewUrl: ":baseUrl/api/preview?contentType=:contentType&id=:id",
       },
     });
   }

--- a/src/services/preview.ts
+++ b/src/services/preview.ts
@@ -39,7 +39,7 @@ module.exports = {
     const model = await global.strapi.query(contentType)?.model;
 
     if (model) {
-      return model.options.previewable;
+      return model.pluginOptions['preview-content'].previewable || model.options.previewable;
     }
     throw new PreviewError(400, "Wrong contentType");
   },
@@ -118,23 +118,43 @@ module.exports = {
     contentId: string,
     _query: Record<string, string | number>
   ) {
+    //@ts-ignore
+    const contentTypeModel = strapi.models[contentType]
+    const contentTypeConfig = contentTypeModel?.pluginOptions?.['preview-content'];
+
     const entity = await this.getSettings();
 
-    const previewUrl = entity.previewUrl || "";
+    const previewUrl = contentTypeConfig?.url || entity.previewUrl || "";
+    const baseUrl = entity.baseUrl || "";
 
-    return this.replacePreviewParams(contentType, contentId, previewUrl);
+    // Fetch data that needs to be put into the url (if enabled)
+    let additionalValues = {}
+    if (contentTypeConfig?.usesValuesInUrl) {
+      // Fetch the data
+      //@ts-ignore
+      additionalValues = await strapi.query(contentType).findOne({ id: contentId })
+    }
+
+    return this.replacePreviewParams(baseUrl, contentType, contentId, previewUrl, additionalValues);
   },
   /**
    * Replace URL from string params
    *
+   * @param - The root url of the project's frontend
    * @param - The content type to query
    * @param - The content type id to query
    * @param - The url string to replace
+   * @param - Additional data of the specific content type that needs to be injected into the url
    *
    * @returns The replaced URL
    */
-  replacePreviewParams(contentType: string, contentId: string, url: string) {
-    return url.replace(":contentType", contentType).replace(":id", contentId);
+  replacePreviewParams(baseUrl: string, contentType: string, contentId: string, url: string, additionalValues: object) {
+    return _.template(
+      url
+        .replace(":baseUrl", baseUrl)
+        .replace(":contentType", contentType)
+        .replace(":id", contentId)
+    )(additionalValues);
   },
   /**
    * Get settings of the plugin

--- a/src/services/preview.ts
+++ b/src/services/preview.ts
@@ -118,7 +118,7 @@ module.exports = {
     contentId: string,
     _query: Record<string, string | number>
   ) {
-    //@ts-ignore
+    // @ts-ignore
     const contentTypeModel = strapi.models[contentType]
     const contentTypeConfig = contentTypeModel?.pluginOptions?.['preview-content'];
 
@@ -131,7 +131,7 @@ module.exports = {
     let additionalValues = {}
     if (contentTypeConfig?.usesValuesInUrl) {
       // Fetch the data
-      //@ts-ignore
+      // @ts-ignore
       additionalValues = await strapi.query(contentType).findOne({ id: contentId })
     }
 

--- a/src/services/preview.ts
+++ b/src/services/preview.ts
@@ -39,7 +39,7 @@ module.exports = {
     const model = await global.strapi.query(contentType)?.model;
 
     if (model) {
-      return model.pluginOptions['preview-content'].previewable || model.options.previewable;
+      return model.pluginOptions?.['preview-content']?.previewable || model.options?.previewable;
     }
     throw new PreviewError(400, "Wrong contentType");
   },


### PR DESCRIPTION
Read the updated README to get an overview of what's new ;)

This uses the `pluginOptions` for a model's settings introduced in Strapi v.3.6.x. See the README for examples. It is implemented in a way that still allows activating the preview and clone buttons using the "normal" `options` (See [services/preview.ts line 42](https://github.com/pr0gr8mm3r/strapi-plugin-preview-content/blob/5492eeff0e7555459573a570871b7dcb864cd3a7/src/services/preview.ts#L42)):
```json
"options": {
  "previewable": true
},
```
I made that switch because the i18n plugin (and others) by Strapi use it and it seems to be the new way for plugins to add their options. Theoretically you could also add fields to the content type builder to configure these options like the i18n plugin, but the api is undocumented and might change, so I didn't do that.


Closes #11 