### PR TITLE
fix: pass apiID to CustomTable to show preview button in list view

### DIFF
--- a/strapi-files/v3.6.x/extensions/content-manager/admin/src/containers/ListView/index.js
+++ b/strapi-files/v3.6.x/extensions/content-manager/admin/src/containers/ListView/index.js
@@ -448,6 +448,7 @@ function ListView({
                     isBulkable={isBulkable}
                     setQuery={setQuery}
                     showLoader={isLoading}
+                    apiID={contentType.apiID}
                   />
                   <Footer count={total} params={query} onChange={setQuery} />
                 </div>


### PR DESCRIPTION
close #19

The problem was simple, `CustomTable` component needed the `apiID` to check if the content type is previewable or not. This prop wasn't passed from `ListView` component. I just passed it and it worked like a charm 🎩 