### PR TITLE
Update preview service to work with plugin content-type

### DIFF
--- a/src/services/preview.ts
+++ b/src/services/preview.ts
@@ -36,7 +36,11 @@ module.exports = {
    * @returns - Returns inf content type is previewable
    */
   async isPreviewable(contentType: string) {
-    const model = await global.strapi.query(contentType)?.model;
+    // check if the wanted content-type belongs to a plugin, then queries the db providing the right scope
+    const pluginEntry = Object.entries<any>(global.strapi.plugins).find(([_, plugin]) => contentType in plugin.models);
+    const pluginName = pluginEntry && pluginEntry[0];
+
+    const model = await global.strapi.query(contentType, pluginName)?.model;
 
     if (model) {
       return model.pluginOptions?.['preview-content']?.previewable || model.options?.previewable;


### PR DESCRIPTION
When querying a content-type to check if it's previewable, looks if it belongs to a plugin, then queries the db providing the name of the corresponding plugin. This allows to match the content-type's model even if is handled by a plugin.